### PR TITLE
Phase 2 Task 2: Add new issue creation functionality

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -67,6 +67,19 @@ function buildMainCard(isLoading) {
     try {
       const issues = fetchUserIssues();
 
+      // Add "Create New Issue" button at the top
+      section.addWidget(
+        CardService.newTextButton()
+          .setText('➕ 新規issue作成')
+          .setOnClickAction(
+            CardService.newAction()
+              .setFunctionName('onCreateNewIssue')
+          )
+          .setTextButtonStyle(CardService.TextButtonStyle.FILLED)
+      );
+
+      section.addWidget(CardService.newDivider());
+
       if (!issues || issues.length === 0) {
         section.addWidget(
           CardService.newTextParagraph()
@@ -356,4 +369,233 @@ function onSubmitCreateEvent(e) {
       .setNotification(notification)
       .build();
   }
+}
+
+/**
+ * Handles create new issue button click
+ * Shows issue creation form
+ * @param {Object} e - Event object
+ * @return {ActionResponse} Response with issue creation card
+ */
+function onCreateNewIssue(e) {
+  Logger.log('onCreateNewIssue triggered');
+
+  // Build issue creation card
+  const card = buildIssueCreationCard();
+
+  const navigation = CardService.newNavigation()
+    .pushCard(card);
+
+  return CardService.newActionResponseBuilder()
+    .setNavigation(navigation)
+    .build();
+}
+
+/**
+ * Builds the issue creation form card
+ * @return {Card} Issue creation card
+ */
+function buildIssueCreationCard() {
+  const card = CardService.newCardBuilder();
+
+  card.setHeader(
+    CardService.newCardHeader()
+      .setTitle('➕ 新規issue作成')
+      .setSubtitle('GitHubに新しいissueを作成')
+  );
+
+  const section = CardService.newCardSection();
+
+  // Repository selection
+  const owner = PropertiesService.getScriptProperties().getProperty('GITHUB_REPO_OWNER');
+  const repo = PropertiesService.getScriptProperties().getProperty('GITHUB_REPO_NAME');
+
+  if (!owner || !repo) {
+    section.addWidget(
+      CardService.newTextParagraph()
+        .setText('⚠️ リポジトリ設定が必要です。\n\nスクリプトプロパティで以下を設定してください：\n• GITHUB_REPO_OWNER\n• GITHUB_REPO_NAME')
+    );
+
+    card.addSection(section);
+    return card.build();
+  }
+
+  // Display repository info
+  section.addWidget(
+    CardService.newDecoratedText()
+      .setText('<b>作成先リポジトリ</b>')
+      .setBottomLabel('📁 ' + owner + '/' + repo)
+  );
+
+  section.addWidget(CardService.newDivider());
+
+  // Issue title input
+  section.addWidget(
+    CardService.newTextInput()
+      .setFieldName('issueTitle')
+      .setTitle('Issueタイトル *')
+      .setHint('タスクの概要を入力してください')
+  );
+
+  // Issue body input
+  section.addWidget(
+    CardService.newTextInput()
+      .setFieldName('issueBody')
+      .setTitle('説明')
+      .setHint('詳細な説明を入力してください（任意）')
+      .setMultiline(true)
+  );
+
+  section.addWidget(CardService.newDivider());
+
+  // Create button
+  section.addWidget(
+    CardService.newTextButton()
+      .setText('➕ Issueを作成')
+      .setOnClickAction(
+        CardService.newAction()
+          .setFunctionName('onSubmitCreateIssue')
+          .setParameters({
+            'owner': owner,
+            'repo': repo
+          })
+      )
+      .setTextButtonStyle(CardService.TextButtonStyle.FILLED)
+  );
+
+  card.addSection(section);
+
+  return card.build();
+}
+
+/**
+ * Handles issue creation form submission
+ * Creates GitHub issue with the provided data
+ * @param {Object} e - Event object with form inputs
+ * @return {ActionResponse} Response with notification and success card
+ */
+function onSubmitCreateIssue(e) {
+  Logger.log('onSubmitCreateIssue triggered');
+
+  try {
+    const formInputs = e.formInput;
+    const params = e.parameters;
+
+    const issueTitle = formInputs.issueTitle;
+    const issueBody = formInputs.issueBody || '';
+    const owner = params.owner;
+    const repo = params.repo;
+
+    // Validate title
+    if (!issueTitle || issueTitle.trim() === '') {
+      const notification = CardService.newNotification()
+        .setText('❌ Issueタイトルを入力してください');
+
+      return CardService.newActionResponseBuilder()
+        .setNotification(notification)
+        .build();
+    }
+
+    Logger.log('Creating issue: ' + issueTitle + ' in ' + owner + '/' + repo);
+
+    // Create issue via GitHub API
+    const createdIssue = createGitHubIssue(owner, repo, issueTitle, issueBody);
+
+    Logger.log('Issue created successfully: ' + createdIssue.url);
+
+    // Show success card with issue details
+    const successCard = buildIssueCreatedCard(createdIssue);
+
+    const navigation = CardService.newNavigation()
+      .updateCard(successCard);
+
+    const notification = CardService.newNotification()
+      .setText('✅ Issue #' + createdIssue.number + ' を作成しました');
+
+    return CardService.newActionResponseBuilder()
+      .setNotification(notification)
+      .setNavigation(navigation)
+      .build();
+
+  } catch (error) {
+    Logger.log('Error creating issue: ' + error.message);
+    Logger.log('Error stack: ' + error.stack);
+
+    const notification = CardService.newNotification()
+      .setText('❌ エラー: ' + error.message);
+
+    return CardService.newActionResponseBuilder()
+      .setNotification(notification)
+      .build();
+  }
+}
+
+/**
+ * Builds the success card after issue creation
+ * @param {Object} issue - Created issue object
+ * @return {Card} Success card
+ */
+function buildIssueCreatedCard(issue) {
+  const card = CardService.newCardBuilder();
+
+  card.setHeader(
+    CardService.newCardHeader()
+      .setTitle('✅ Issue作成完了')
+      .setSubtitle('Issue #' + issue.number)
+  );
+
+  const section = CardService.newCardSection();
+
+  // Issue details
+  section.addWidget(
+    CardService.newDecoratedText()
+      .setText('<b>' + issue.title + '</b>')
+      .setBottomLabel('Status: ' + issue.state)
+      .setOpenLink(CardService.newOpenLink().setUrl(issue.url))
+  );
+
+  section.addWidget(CardService.newDivider());
+
+  // Issue URL
+  section.addWidget(
+    CardService.newTextParagraph()
+      .setText('<b>Issue URL:</b>')
+  );
+
+  section.addWidget(
+    CardService.newTextParagraph()
+      .setText('<a href="' + issue.url + '">' + issue.url + '</a>')
+  );
+
+  section.addWidget(CardService.newDivider());
+
+  // Back button
+  section.addWidget(
+    CardService.newTextButton()
+      .setText('← サイドバーに戻る')
+      .setOnClickAction(
+        CardService.newAction()
+          .setFunctionName('onBackToMain')
+      )
+  );
+
+  card.addSection(section);
+
+  return card.build();
+}
+
+/**
+ * Handles back to main button click
+ * @param {Object} e - Event object
+ * @return {ActionResponse} Response navigating back to main
+ */
+function onBackToMain(e) {
+  Logger.log('onBackToMain triggered');
+
+  const navigation = CardService.newNavigation()
+    .popToRoot();
+
+  return CardService.newActionResponseBuilder()
+    .setNavigation(navigation)
+    .build();
 }

--- a/src/Test.js
+++ b/src/Test.js
@@ -143,10 +143,50 @@ function testCreateCalendarEvent() {
 }
 
 /**
+ * Test: Issue creation form card
+ */
+function testIssueCreationForm() {
+  Logger.log('=== Testing Issue Creation Form ===');
+
+  try {
+    const card = buildIssueCreationCard();
+    Logger.log('✓ Issue creation form作成成功');
+    Logger.log('Card object: ' + (card ? 'OK' : 'NG'));
+  } catch (error) {
+    Logger.log('❌ エラー: ' + error.message);
+    Logger.log('Stack: ' + error.stack);
+  }
+}
+
+/**
+ * Test: Success card after issue creation
+ */
+function testIssueCreatedCard() {
+  Logger.log('=== Testing Issue Created Card ===');
+
+  try {
+    const mockIssue = {
+      number: 123,
+      title: 'Test Issue',
+      state: 'open',
+      url: 'https://github.com/test/repo/issues/123'
+    };
+
+    const card = buildIssueCreatedCard(mockIssue);
+    Logger.log('✓ Issue created card作成成功');
+    Logger.log('Card object: ' + (card ? 'OK' : 'NG'));
+  } catch (error) {
+    Logger.log('❌ エラー: ' + error.message);
+    Logger.log('Stack: ' + error.stack);
+  }
+}
+
+/**
  * Test: Create a test issue (use with caution)
  */
 function testCreateIssue() {
   Logger.log('=== Testing Create Issue ===');
+  Logger.log('⚠️ 警告: この関数は実際にGitHubにissueを作成します');
 
   const owner = PropertiesService.getScriptProperties().getProperty('GITHUB_REPO_OWNER');
   const repo = PropertiesService.getScriptProperties().getProperty('GITHUB_REPO_NAME');
@@ -167,6 +207,7 @@ function testCreateIssue() {
     Logger.log('✓ Issue作成成功');
     Logger.log('Issue #' + testIssue.number);
     Logger.log('URL: ' + testIssue.url);
+    Logger.log('⚠️ GitHubで作成されたissueを確認してください');
   } catch (error) {
     Logger.log('❌ エラー: ' + error.message);
   }
@@ -234,10 +275,18 @@ function runAllTests() {
   Logger.log('\n');
 
   testEventCreationForm();
+  Logger.log('\n');
+
+  testIssueCreationForm();
+  Logger.log('\n');
+
+  testIssueCreatedCard();
 
   Logger.log('\n========================================');
   Logger.log('  Tests Complete');
   Logger.log('========================================');
-  Logger.log('\n⚠️ testCreateCalendarEvent()は実際にイベントを作成するため、runAllTests()には含まれていません');
+  Logger.log('\n⚠️ 以下のテストは実際にデータを作成するため、runAllTests()には含まれていません：');
+  Logger.log('• testCreateCalendarEvent() - カレンダーイベントを作成');
+  Logger.log('• testCreateIssue() - GitHubにissueを作成');
   Logger.log('手動で実行してテストしてください');
 }


### PR DESCRIPTION
## 概要
サイドバーに「新規issue作成」ボタンを追加し、GitHubに新しいissueを作成できる機能を実装しました。リポジトリ設定に基づいて、タイトルと説明を入力してissueを作成できます。

## 変更内容

### UIの追加
- **「➕ 新規issue作成」ボタンをサイドバー上部に追加**
  - issue一覧の前に配置
  - issueがない場合でも表示
  - FILLED styleで強調表示
  - すべてのユーザーが利用可能

### Issue作成フロー

#### 1. ボタンクリック: `onCreateNewIssue()`
- Issue作成フォームカードを構築
- 新しいカードにナビゲーション（pushCard）

#### 2. フォーム表示: `buildIssueCreationCard()`
- **ヘッダー**: 「➕ 新規issue作成」 / 「GitHubに新しいissueを作成」
- **リポジトリ情報表示**:
  - GITHUB_REPO_OWNERとGITHUB_REPO_NAMEから取得
  - 設定されていない場合は警告メッセージを表示
- **入力フォーム**:
  - **Issueタイトル** (必須): タスクの概要
  - **説明** (任意): 詳細な説明（複数行）
- **作成ボタン**: FILLED styleで強調表示

#### 3. Issue作成: `onSubmitCreateIssue()`
- フォーム入力値の検証
  - タイトルが空でないことを確認
- GitHub APIでissueを作成
  - createGitHubIssue()を呼び出し
  - owner, repo, title, bodyを渡す
- 成功時:
  - ✅ 通知: 「Issue #123 を作成しました」
  - 成功カードを表示（updateCard）
- エラー時:
  - ❌ 通知: エラーメッセージ
  - 詳細なログ出力

#### 4. 成功カード: `buildIssueCreatedCard()`
- **Issue詳細**:
  - Issue番号とタイトル
  - ステータス
  - クリック可能なURL
- **Issue URL表示**: テキストとリンク
- **「← サイドバーに戻る」ボタン**:
  - onBackToMain()を呼び出し
  - popToRoot()でメインカードに戻る

### リポジトリ設定

スクリプトプロパティで以下を設定：
- `GITHUB_REPO_OWNER`: リポジトリオーナー名
- `GITHUB_REPO_NAME`: リポジトリ名

設定されていない場合、フォームに警告を表示し、スクリプトプロパティでの設定を案内します。

### テスト関数の追加

1. **testIssueCreationForm()**: フォーム生成のテスト
   - buildIssueCreationCard()が正常に動作するか確認
   - Cardオブジェクトが生成されるか確認

2. **testIssueCreatedCard()**: 成功カードのテスト
   - モックデータで成功カードを生成
   - Cardオブジェクトが正常に生成されるか確認

3. **testCreateIssue()**: 実際のissue作成テスト
   - ⚠️ 警告: 実際にGitHubにissueを作成します
   - リポジトリ設定が必要
   - 手動実行を推奨

4. **runAllTests()の更新**
   - testIssueCreationForm()とtestIssueCreatedCard()を追加
   - testCreateIssue()は手動実行を推奨（警告メッセージ付き）

## 動作確認方法

### 1. リポジトリ設定

GAS Editorで：
1. 「プロジェクトの設定」（歯車アイコン）
2. 「スクリプトプロパティ」セクション
3. 以下を追加：
   - `GITHUB_REPO_OWNER`: 例）HappyMana
   - `GITHUB_REPO_NAME`: 例）gcal-github-time-tracker

### 2. GAS Editorでテスト

```javascript
testIssueCreationForm()  // フォーム生成テスト
testIssueCreatedCard()   // 成功カード生成テスト
testCreateIssue()        // 実際のissue作成テスト（⚠️実際にissueを作成）
runAllTests()            // 全テスト実行（issue作成は含まれない）
```

### 3. Google Calendarで実際に試す

1. テストデプロイを更新
2. Google Calendarのサイドバーを開く
3. 「➕ 新規issue作成」ボタンをクリック
4. フォームが表示される:
   - リポジトリ情報を確認
   - タイトルと説明を入力
5. 「➕ Issueを作成」ボタンをクリック
6. 成功通知が表示される
7. 成功カードにissue詳細とURLが表示される
8. 「← サイドバーに戻る」ボタンでメインに戻る
9. GitHubでissueが作成されていることを確認

## 受け入れ基準の達成状況

- [x] サイドバーに「新規issue作成」ボタンが表示される
- [x] ボタンをクリックすると、issue作成フォームが表示される
- [x] フォームから送信すると、GitHubに新規issueが作成される
- [x] 作成成功後、issueのURLが表示される
- [x] リポジトリ設定の検証とガイダンス
- [x] タイトル入力の検証

## 技術的詳細

### CardServiceの機能活用
- **Navigation**: 
  - pushCard(): 新しいカードに遷移
  - updateCard(): 現在のカードを更新
  - popToRoot(): ルートカードに戻る
- **TextInput**: 
  - 単一行: タイトル入力
  - 複数行（multiline）: 説明入力
  - setHint(): プレースホルダー
- **Validation**: フォーム送信前にタイトルをチェック
- **Notification**: ユーザーフィードバック

### GitHub API
- `createGitHubIssue(owner, repo, title, body)`を使用
- GitHubAPI.jsで既に実装済みの関数を活用
- 認証はOAuth2またはPATで自動処理

### エラーハンドリング
- タイトル空欄チェック
- リポジトリ設定チェック
- GitHub API エラーのキャッチ
- 詳細なログ出力（スタックトレース含む）

## スクリーンショット

（Google Calendarサイドバーでの実際の動作を確認してください）

## 関連Issue

Closes #6

## Phase 2完了

Phase 2の両タスクが完了しました：
- ✅ Task 1: issueから予定を作成（#17）
- ✅ Task 2: 新規issue作成（このPR）

次は**Phase 3: 工数集計機能**に進みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)